### PR TITLE
fix: coerce null arrays to [] in API layer to prevent page crashes

### DIFF
--- a/src/lib/api/actuaries.ts
+++ b/src/lib/api/actuaries.ts
@@ -11,7 +11,7 @@ export async function getActuaries(filters: ActuaryFilters = {}): Promise<Actuar
   const { data } = await apiClient.get<ActuaryListResponse>('/api/actuaries', {
     params: filters,
   })
-  return data
+  return { ...data, actuaries: data.actuaries ?? [] }
 }
 
 export async function setActuaryLimit(id: number, payload: SetLimitPayload): Promise<Actuary> {

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -14,7 +14,7 @@ export async function createOrder(payload: CreateOrderPayload): Promise<Order> {
 
 export async function getMyOrders(filters: MyOrderFilters = {}): Promise<OrderListResponse> {
   const { data } = await apiClient.get<OrderListResponse>('/api/me/orders', { params: filters })
-  return data
+  return { ...data, orders: data.orders ?? [] }
 }
 
 export async function getMyOrder(id: number): Promise<Order> {
@@ -29,7 +29,7 @@ export async function cancelOrder(id: number): Promise<Order> {
 
 export async function getAllOrders(filters: AdminOrderFilters = {}): Promise<OrderListResponse> {
   const { data } = await apiClient.get<OrderListResponse>('/api/orders', { params: filters })
-  return data
+  return { ...data, orders: data.orders ?? [] }
 }
 
 export async function approveOrder(id: number): Promise<Order> {

--- a/src/lib/api/otc.ts
+++ b/src/lib/api/otc.ts
@@ -8,7 +8,8 @@ export async function getOtcOffers(filters?: OtcFilters): Promise<OtcOfferListRe
   if (filters?.security_type) params.append('security_type', filters.security_type)
   if (filters?.ticker) params.append('ticker', filters.ticker)
   const response = await apiClient.get<OtcOfferListResponse>('/api/otc/offers', { params })
-  return response.data
+  const data = response.data
+  return { ...data, offers: data.offers ?? [] }
 }
 
 export async function buyOtcOffer(id: number, payload: OtcBuyRequest): Promise<void> {

--- a/src/lib/api/portfolio.ts
+++ b/src/lib/api/portfolio.ts
@@ -11,7 +11,7 @@ export async function getPortfolio(filters: PortfolioFilters = {}): Promise<Hold
   const { data } = await apiClient.get<HoldingListResponse>('/api/me/portfolio', {
     params: filters,
   })
-  return data
+  return { ...data, holdings: data.holdings ?? [] }
 }
 
 export async function getPortfolioSummary(): Promise<PortfolioSummary> {

--- a/src/lib/api/securities.ts
+++ b/src/lib/api/securities.ts
@@ -20,7 +20,7 @@ export async function getStocks(filters: StockFilters = {}): Promise<StockListRe
   const { data } = await apiClient.get<StockListResponse>('/api/securities/stocks', {
     params: filters,
   })
-  return data
+  return { ...data, stocks: data.stocks ?? [] }
 }
 
 export async function getStock(id: number): Promise<Stock> {
@@ -36,14 +36,14 @@ export async function getStockHistory(
     `/api/securities/stocks/${id}/history`,
     { params: filters }
   )
-  return data
+  return { ...data, history: data.history ?? [] }
 }
 
 export async function getFutures(filters: FuturesFilters = {}): Promise<FuturesListResponse> {
   const { data } = await apiClient.get<FuturesListResponse>('/api/securities/futures', {
     params: filters,
   })
-  return data
+  return { ...data, futures: data.futures ?? [] }
 }
 
 export async function getFuture(id: number): Promise<FuturesContract> {
@@ -59,14 +59,14 @@ export async function getFutureHistory(
     `/api/securities/futures/${id}/history`,
     { params: filters }
   )
-  return data
+  return { ...data, history: data.history ?? [] }
 }
 
 export async function getForexPairs(filters: ForexFilters = {}): Promise<ForexListResponse> {
   const { data } = await apiClient.get<ForexListResponse>('/api/securities/forex', {
     params: filters,
   })
-  return data
+  return { ...data, forex_pairs: data.forex_pairs ?? [] }
 }
 
 export async function getForexPair(id: number): Promise<ForexPair> {
@@ -82,14 +82,14 @@ export async function getForexHistory(
     `/api/securities/forex/${id}/history`,
     { params: filters }
   )
-  return data
+  return { ...data, history: data.history ?? [] }
 }
 
 export async function getOptions(filters: OptionsFilters): Promise<OptionsListResponse> {
   const { data } = await apiClient.get<OptionsListResponse>('/api/securities/options', {
     params: filters,
   })
-  return data
+  return { ...data, options: data.options ?? [] }
 }
 
 export async function getOption(id: number): Promise<Option> {

--- a/src/lib/api/stockExchanges.ts
+++ b/src/lib/api/stockExchanges.ts
@@ -11,7 +11,7 @@ export async function getStockExchanges(
   const { data } = await apiClient.get<StockExchangeListResponse>('/api/stock-exchanges', {
     params: filters,
   })
-  return data
+  return { ...data, exchanges: data.exchanges ?? [] }
 }
 
 export async function getTestingMode(): Promise<TestingModeResponse> {

--- a/src/lib/api/tax.ts
+++ b/src/lib/api/tax.ts
@@ -3,7 +3,7 @@ import type { TaxListResponse, TaxFilters, CollectTaxResponse } from '@/types/ta
 
 export async function getTaxRecords(filters: TaxFilters = {}): Promise<TaxListResponse> {
   const { data } = await apiClient.get<TaxListResponse>('/api/tax', { params: filters })
-  return data
+  return { ...data, tax_records: data.tax_records ?? [] }
 }
 
 export async function collectTaxes(): Promise<CollectTaxResponse> {


### PR DESCRIPTION
Backend returns null instead of [] for list fields (e.g. orders, holdings) when there are no results, causing "Cannot read properties of null" errors on multiple pages. Normalizes at the API boundary so all downstream code is protected.