### PR TITLE
fix(auth): support path-param password reset links to prevent catch-a…

### DIFF
--- a/cypress/e2e/password-reset.cy.ts
+++ b/cypress/e2e/password-reset.cy.ts
@@ -1,4 +1,37 @@
 describe('Password Reset Page', () => {
+  it('should display the password reset form via path param URL', () => {
+    cy.visit('/password-reset/test-token-123')
+
+    cy.contains('Set New Password').should('be.visible')
+    cy.get('#new_password').should('be.visible')
+    cy.get('#confirm_password').should('be.visible')
+    cy.contains('button', 'Reset Password').should('be.visible')
+  })
+
+  it('should submit new password via path param token', () => {
+    cy.intercept('POST', '**/api/v3/auth/password/reset', { statusCode: 200, body: {} }).as(
+      'resetPassword'
+    )
+
+    cy.visit('/password-reset/test-token-123')
+
+    cy.get('#new_password').type('NewPassword12!')
+    cy.get('#confirm_password').type('NewPassword12!')
+    cy.contains('button', 'Reset Password').click()
+
+    cy.wait('@resetPassword')
+    cy.get('@resetPassword')
+      .its('request.body')
+      .should((body) => {
+        expect(body.token).to.equal('test-token-123')
+        expect(body.new_password).to.equal('NewPassword12!')
+        expect(body.confirm_password).to.equal('NewPassword12!')
+      })
+
+    cy.contains('Password reset successfully.').should('be.visible')
+    cy.contains('Log in').should('be.visible')
+  })
+
   it('should display the password reset form', () => {
     cy.visit('/password-reset?token=test-token-123')
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/password-reset-request" element={<PasswordResetRequestPage />} />
         <Route path="/password-reset" element={<PasswordResetPage />} />
+        <Route path="/password-reset/:token" element={<PasswordResetPage />} />
         <Route path="/activate" element={<ActivationPage />} />
       </Route>
 

--- a/src/pages/PasswordResetPage.test.tsx
+++ b/src/pages/PasswordResetPage.test.tsx
@@ -9,6 +9,27 @@ jest.mock('@/lib/api/auth')
 beforeEach(() => jest.clearAllMocks())
 
 describe('PasswordResetPage', () => {
+  it('reads token from URL path parameter', async () => {
+    jest.mocked(authApi.resetPassword).mockResolvedValue(undefined)
+
+    renderWithProviders(<PasswordResetPage />, {
+      route: '/password-reset/my-path-token',
+      routePath: '/password-reset/:token',
+    })
+
+    await userEvent.type(screen.getByLabelText(/new password/i), 'Password12')
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'Password12')
+    await userEvent.click(screen.getByRole('button', { name: /reset password/i }))
+
+    await waitFor(() => {
+      expect(authApi.resetPassword).toHaveBeenCalledWith({
+        token: 'my-path-token',
+        new_password: 'Password12',
+        confirm_password: 'Password12',
+      })
+    })
+  })
+
   it('calls resetPassword API with token from URL', async () => {
     jest.mocked(authApi.resetPassword).mockResolvedValue(undefined)
 

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, useParams } from 'react-router-dom'
 import { useMutation } from '@tanstack/react-query'
 import { PasswordResetForm } from '@/components/auth/PasswordResetForm'
 import { resetPassword } from '@/lib/api/auth'
@@ -6,7 +6,8 @@ import type { PasswordResetPayload } from '@/types/auth'
 
 export function PasswordResetPage() {
   const [searchParams] = useSearchParams()
-  const token = searchParams.get('token') ?? ''
+  const { token: pathToken } = useParams<{ token?: string }>()
+  const token = searchParams.get('token') ?? pathToken ?? ''
 
   const mutation = useMutation({
     mutationFn: (data: { new_password: string; confirm_password: string }) =>


### PR DESCRIPTION
…ll redirect

Backend reset emails use /password-reset/:token (path param) instead of /password-reset?token=... (query param). The missing route caused React Router's catch-all to fire, immediately redirecting users to /login before they ever saw the reset form.

- Add /password-reset/:token route alongside the existing /password-reset
- PasswordResetPage now reads token from useParams as fallback to useSearchParams
- Cypress e2e extended with path-param URL format tests