### PR TITLE
fix(otc): replace peer-otc bid route with option-style bid and fix re…

### DIFF
--- a/cypress/e2e/funds-celina4.cy.ts
+++ b/cypress/e2e/funds-celina4.cy.ts
@@ -121,7 +121,7 @@ describe('Celina 4 — Investicioni fondovi: Discovery i detalji', () => {
     // carried the full term rather than waiting on the first (search=A).
     cy.get('#funds-search').type('Alpha')
     cy.get('@getFilteredFunds.all').should((calls) => {
-      expect(calls.some((c) => c.request.url.includes('search=Alpha'))).to.be.true
+      expect(calls.some((c) => c.request.url.includes('search=Alpha'))).to.equal(true)
     })
   })
 

--- a/src/__tests__/fixtures/otc-fixtures.ts
+++ b/src/__tests__/fixtures/otc-fixtures.ts
@@ -20,6 +20,7 @@ export function createMockOtcOffer(overrides: Partial<OtcLocalOffer> = {}): OtcL
 export function createMockRemoteOtcOffer(overrides: Partial<OtcRemoteOffer> = {}): OtcRemoteOffer {
   return {
     kind: 'remote',
+    id: 10,
     bank_code: '333',
     owner_id: '0',
     security_type: 'stock',

--- a/src/components/notifications/NotificationDropdown.test.tsx
+++ b/src/components/notifications/NotificationDropdown.test.tsx
@@ -2,12 +2,21 @@ import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@/__tests__/utils/test-utils'
 import { NotificationDropdown } from './NotificationDropdown'
 import * as notificationsApi from '@/lib/api/notifications'
-import { mockNotifications } from '@/__tests__/fixtures/notification-fixtures'
+import {
+  mockNotifications,
+  createMockNotification,
+} from '@/__tests__/fixtures/notification-fixtures'
 
+const mockNavigate = jest.fn()
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}))
 jest.mock('@/lib/api/notifications')
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockNavigate.mockClear()
   jest.mocked(notificationsApi.getNotifications).mockResolvedValue({
     notifications: mockNotifications,
     total: mockNotifications.length,
@@ -52,6 +61,40 @@ describe('NotificationDropdown', () => {
     await screen.findByText(mockNotifications[0].title)
     fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }))
     await waitFor(() => expect(notificationsApi.markAllNotificationsRead).toHaveBeenCalledTimes(1))
+  })
+
+  it('navigates to /otc/options when an OTC counter notification is clicked', async () => {
+    const otcNotification = createMockNotification({
+      id: 10,
+      type: 'OTC_OFFER_COUNTERED',
+      title: 'Counter received',
+      message: 'The owner countered your bid.',
+      is_read: false,
+      ref_type: 'otc_negotiation',
+      ref_id: null,
+    })
+    jest.mocked(notificationsApi.getNotifications).mockResolvedValue({
+      notifications: [otcNotification],
+      total: 1,
+    })
+
+    renderWithProviders(<NotificationDropdown />)
+    const item = await screen.findByRole('button', { name: /counter received/i })
+    fireEvent.click(item)
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/otc/options'))
+  })
+
+  it('does not navigate for standard (non-OTC) notification types', async () => {
+    jest.mocked(notificationsApi.getNotifications).mockResolvedValue({
+      notifications: [createMockNotification({ id: 5, type: 'money_received', is_read: false })],
+      total: 1,
+    })
+
+    renderWithProviders(<NotificationDropdown />)
+    const item = await screen.findByRole('button', { name: /money received/i })
+    fireEvent.click(item)
+    await waitFor(() => expect(notificationsApi.markNotificationRead).toHaveBeenCalledWith(5))
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('hides "Mark all as read" when there are no unread items', async () => {

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import {
   useNotifications,
   useMarkNotificationRead,
@@ -8,9 +9,19 @@ import { Button } from '@/components/ui/button'
 import { NotificationItem } from './NotificationItem'
 import type { Notification } from '@/types/notification'
 
+function resolveNavigationPath(n: Notification): string | null {
+  // OTC event notifications (SCREAMING_SNAKE_CASE per SI-TX protocol) direct
+  // the user to the OTC Options view where they can find their chain via
+  // GET /me/otc/options/negotiations. ref_id is not always populated for
+  // cross-bank events, so we navigate to the view without a specific offer id.
+  if (n.type.startsWith('OTC_')) return '/otc/options'
+  return null
+}
+
 const PAGE_SIZE = 10
 
 export function NotificationDropdown() {
+  const navigate = useNavigate()
   const { data, isLoading, isError } = useNotifications({ page: 1, page_size: PAGE_SIZE })
   const markOne = useMarkNotificationRead()
   const markAll = useMarkAllNotificationsRead()
@@ -20,6 +31,8 @@ export function NotificationDropdown() {
 
   const handleItemClick = (n: Notification) => {
     if (!n.is_read) markOne.mutate(n.id)
+    const path = resolveNavigationPath(n)
+    if (path) navigate(path)
   }
 
   return (

--- a/src/hooks/useOtc.test.ts
+++ b/src/hooks/useOtc.test.ts
@@ -4,17 +4,21 @@ import {
   useOtcOffers,
   useBuyOtcOffer,
   useBuyOtcOfferOnBehalf,
-  useCreatePeerOtcNegotiation,
+  usePlaceBidOnRemoteOffer,
 } from '@/hooks/useOtc'
 import * as otcApi from '@/lib/api/otc'
+import * as otcOptionsApiModule from '@/views/otcOptions/api/otcOptionsApi'
 import { createMockOtcOfferListResponse } from '@/__tests__/fixtures/otc-fixtures'
 
 jest.mock('@/lib/api/otc')
+jest.mock('@/views/otcOptions/api/otcOptionsApi', () => ({
+  otcOptionsApi: { placeBid: jest.fn() },
+}))
 
 const mockGetOtcOffers = jest.mocked(otcApi.getOtcOffers)
 const mockBuyOtcOffer = jest.mocked(otcApi.buyOtcOffer)
 const mockBuyOtcOfferOnBehalf = jest.mocked(otcApi.buyOtcOfferOnBehalf)
-const mockCreatePeerOtcNegotiation = jest.mocked(otcApi.createPeerOtcNegotiation)
+const mockPlaceBid = jest.mocked(otcOptionsApiModule.otcOptionsApi.placeBid)
 
 beforeEach(() => jest.clearAllMocks())
 
@@ -28,25 +32,32 @@ describe('useOtcOffers', () => {
   })
 })
 
-describe('useCreatePeerOtcNegotiation', () => {
-  it('forwards the negotiation payload to the api', async () => {
-    mockCreatePeerOtcNegotiation.mockResolvedValue({ routingNumber: 333, id: 'abc' })
-    const { result } = renderHook(() => useCreatePeerOtcNegotiation(), {
+describe('usePlaceBidOnRemoteOffer', () => {
+  it('calls otcOptionsApi.placeBid with the offerId and bid payload', async () => {
+    mockPlaceBid.mockResolvedValue({ negotiation: {} as any })
+    const { result } = renderHook(() => usePlaceBidOnRemoteOffer(), {
       wrapper: createQueryWrapper(),
     })
-    const payload = {
-      seller_bank_code: '333',
-      seller_id: '0',
-      stock: { ticker: 'MSFT' },
-      amount: 2,
-      settlement_date: '2027-08-01T00:00:00.000Z',
-      price_per_unit: { amount: '420.50', currency: 'USD' },
-      premium: { amount: '40', currency: 'USD' },
+    const input = {
+      offerId: 42,
+      bidder_account_id: 13,
+      quantity: '2',
+      strike_price: '175.00',
+      premium: '40.00',
+      settlement_date: '2027-08-01',
     }
     await act(async () => {
-      result.current.mutate(payload)
+      result.current.mutate(input)
     })
-    await waitFor(() => expect(mockCreatePeerOtcNegotiation).toHaveBeenCalledWith(payload))
+    await waitFor(() =>
+      expect(mockPlaceBid).toHaveBeenCalledWith(42, {
+        bidder_account_id: 13,
+        quantity: '2',
+        strike_price: '175.00',
+        premium: '40.00',
+        settlement_date: '2027-08-01',
+      })
+    )
   })
 })
 

--- a/src/hooks/useOtc.ts
+++ b/src/hooks/useOtc.ts
@@ -1,11 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import {
-  getOtcOffers,
-  buyOtcOffer,
-  buyOtcOfferOnBehalf,
-  createPeerOtcNegotiation,
-} from '@/lib/api/otc'
-import type { OtcFilters, PeerOtcNegotiationRequest } from '@/types/otc'
+import { getOtcOffers, buyOtcOffer, buyOtcOfferOnBehalf } from '@/lib/api/otc'
+import { otcOptionsApi } from '@/views/otcOptions/api/otcOptionsApi'
+import type { OtcFilters } from '@/types/otc'
+import type { PlaceBidPayload } from '@/views/otcOptions/types'
 
 export function useOtcOffers(filters?: OtcFilters, options?: { enabled?: boolean }) {
   return useQuery({
@@ -54,10 +51,18 @@ export function useBuyOtcOfferOnBehalf() {
   })
 }
 
-export function useCreatePeerOtcNegotiation() {
+export function useRemoteOptionOffers() {
+  return useQuery({
+    queryKey: ['otc-option-offers', 'remote'],
+    queryFn: () => otcOptionsApi.listAll({ kind: 'remote' }),
+  })
+}
+
+export function usePlaceBidOnRemoteOffer() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (payload: PeerOtcNegotiationRequest) => createPeerOtcNegotiation(payload),
+    mutationFn: ({ offerId, ...payload }: { offerId: number } & PlaceBidPayload) =>
+      otcOptionsApi.placeBid(offerId, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['otc-offers'] })
       queryClient.invalidateQueries({ queryKey: ['otc-option-offers'] })

--- a/src/lib/api/otc.test.ts
+++ b/src/lib/api/otc.test.ts
@@ -1,10 +1,5 @@
 import { apiClient } from '@/lib/api/axios'
-import {
-  getOtcOffers,
-  buyOtcOffer,
-  buyOtcOfferOnBehalf,
-  createPeerOtcNegotiation,
-} from '@/lib/api/otc'
+import { getOtcOffers, buyOtcOffer, buyOtcOfferOnBehalf } from '@/lib/api/otc'
 import { createMockOtcOfferListResponse } from '@/__tests__/fixtures/otc-fixtures'
 
 jest.mock('@/lib/api/axios', () => ({
@@ -82,26 +77,5 @@ describe('buyOtcOfferOnBehalf', () => {
       account_id: 12,
       quantity: 3,
     })
-  })
-})
-
-describe('createPeerOtcNegotiation', () => {
-  it('POST /me/peer-otc/negotiations with the negotiation payload', async () => {
-    const responseBody = { routingNumber: 333, id: 'neg-1' }
-    mockPost.mockResolvedValue({ data: responseBody })
-
-    const payload = {
-      seller_bank_code: '333',
-      seller_id: '0',
-      stock: { ticker: 'MSFT' },
-      amount: 2,
-      settlement_date: '2027-08-01T00:00:00.000Z',
-      price_per_unit: { amount: '175', currency: 'USD' },
-      premium: { amount: '40', currency: 'USD' },
-    }
-    const result = await createPeerOtcNegotiation(payload)
-
-    expect(mockPost).toHaveBeenCalledWith('/me/peer-otc/negotiations', payload)
-    expect(result).toEqual(responseBody)
   })
 })

--- a/src/lib/api/otc.ts
+++ b/src/lib/api/otc.ts
@@ -4,8 +4,6 @@ import type {
   OtcFilters,
   OtcBuyRequest,
   OtcBuyOnBehalfRequest,
-  PeerOtcNegotiationRequest,
-  PeerOtcNegotiationResponse,
 } from '@/types/otc'
 
 export async function getOtcOffers(filters?: OtcFilters): Promise<OtcOfferListResponse> {
@@ -37,14 +35,4 @@ export async function buyOtcOfferOnBehalf(
   payload: OtcBuyOnBehalfRequest
 ): Promise<void> {
   await apiClient.post(`/otc/stocks/${id}/buy-on-behalf`, payload)
-}
-
-export async function createPeerOtcNegotiation(
-  payload: PeerOtcNegotiationRequest
-): Promise<PeerOtcNegotiationResponse> {
-  const { data } = await apiClient.post<PeerOtcNegotiationResponse>(
-    '/me/peer-otc/negotiations',
-    payload
-  )
-  return data
 }

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -7,6 +7,12 @@ export type NotificationType =
   | 'loan_approved'
   | 'loan_rejected'
   | 'password_changed'
+  // OTC SI-TX event notifications (SCREAMING_SNAKE_CASE per inter-bank protocol)
+  | 'OTC_OFFER_RECEIVED'
+  | 'OTC_OFFER_COUNTERED'
+  | 'OTC_OFFER_REJECTED'
+  | 'OTC_OFFER_ACCEPTED'
+  | 'OTC_OFFER_CANCELLED'
 
 export interface Notification {
   id: number

--- a/src/types/otc.ts
+++ b/src/types/otc.ts
@@ -20,6 +20,8 @@ export interface OtcLocalOffer {
 
 export interface OtcRemoteOffer {
   kind: 'remote'
+  /** Local surrogate id assigned by stock-service discovery cache — used to address /otc/options/:id/bid. */
+  id: number
   bank_code: string
   owner_id: string
   security_type: 'stock' | 'futures'
@@ -59,24 +61,4 @@ export interface OtcFilters {
   ticker?: string
   kind?: 'local' | 'remote'
   bank_code?: string
-}
-
-export interface MoneyAmount {
-  amount: string
-  currency: string
-}
-
-export interface PeerOtcNegotiationRequest {
-  seller_bank_code: string
-  seller_id: string
-  stock: { ticker: string }
-  amount: number
-  settlement_date: string
-  price_per_unit: MoneyAmount
-  premium: MoneyAmount
-}
-
-export interface PeerOtcNegotiationResponse {
-  routingNumber: number
-  id: string
 }

--- a/src/views/otcOptions/__tests__/BidderActivityPanel.test.tsx
+++ b/src/views/otcOptions/__tests__/BidderActivityPanel.test.tsx
@@ -1,0 +1,130 @@
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@/__tests__/utils/test-utils'
+import { BidderActivityPanel } from '@/views/otcOptions/components/BidderActivityPanel'
+import { otcOptionsApi } from '@/views/otcOptions/api/otcOptionsApi'
+import type { OtcOptionRow, OtcNegotiation, OtcParty } from '@/views/otcOptions/types'
+
+jest.mock('@/views/otcOptions/api/otcOptionsApi', () => ({
+  otcOptionsApi: {
+    listMyNegotiations: jest.fn(),
+    listNegotiations: jest.fn(),
+    getOfferTimeline: jest.fn(),
+    counter: jest.fn(),
+    withdrawNegotiation: jest.fn(),
+  },
+}))
+
+function makeOffer(overrides: Partial<OtcOptionRow> = {}): OtcOptionRow {
+  return {
+    offer_id: '42',
+    kind: 'remote',
+    bank_code: '333',
+    ticker: 'AAPL',
+    amount: '5',
+    strike_price: '175.00',
+    strike_currency: 'USD',
+    premium: '10.00',
+    premium_currency: 'USD',
+    settlement_date: '2027-01-01',
+    direction: 'sell_initiated',
+    status: 'active',
+    active_chains_count: 1,
+    seller_id: 'seller-1',
+    my_negotiation_id: null,
+    ...overrides,
+  } as OtcOptionRow
+}
+
+function makeNegotiation(overrides: Partial<OtcNegotiation> = {}): OtcNegotiation {
+  return {
+    id: 99,
+    parent_offer_id: 999,
+    offer_id: undefined,
+    status: 'open',
+    quantity: '5',
+    strike_price: '175.00',
+    premium: '10.00',
+    settlement_date: '2027-01-01',
+    kind: 'remote',
+    last_action_by: { owner_type: 'client', owner_id: 1 },
+    ...overrides,
+  } as OtcNegotiation
+}
+
+const currentBidder: OtcParty = { owner_type: 'client', owner_id: 1 }
+const onBack = jest.fn()
+const onPlaceBid = jest.fn()
+
+const defaultProps = {
+  offer: makeOffer(),
+  accounts: [],
+  currentBidder,
+  onBack,
+  onPlaceBid,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.mocked(otcOptionsApi.listNegotiations).mockResolvedValue({ negotiations: [], total: 0 })
+  jest.mocked(otcOptionsApi.getOfferTimeline).mockResolvedValue({ offer: {}, timeline: [] })
+})
+
+describe('BidderActivityPanel — chain lookup', () => {
+  it('shows "no bid" state when my_negotiation_id is absent and no parent_offer_id match', async () => {
+    jest.mocked(otcOptionsApi.listMyNegotiations).mockResolvedValue({ negotiations: [], total: 0 })
+
+    renderWithProviders(<BidderActivityPanel {...defaultProps} />)
+    expect(await screen.findByText(/haven't placed a bid/i)).toBeInTheDocument()
+  })
+
+  it('finds the chain via my_negotiation_id even when parent_offer_id differs', async () => {
+    // my_negotiation_id = 99, but parent_offer_id is 999 (remote bank id, NOT local surrogate 42)
+    const offer = makeOffer({ my_negotiation_id: 99 })
+    const negotiation = makeNegotiation({ id: 99, parent_offer_id: 999 })
+
+    jest
+      .mocked(otcOptionsApi.listMyNegotiations)
+      .mockResolvedValue({ negotiations: [negotiation], total: 1 })
+    jest.mocked(otcOptionsApi.listNegotiations).mockResolvedValue({ negotiations: [], total: 0 })
+
+    renderWithProviders(<BidderActivityPanel {...defaultProps} offer={offer} />)
+    await waitFor(() => expect(screen.queryByText(/haven't placed a bid/i)).not.toBeInTheDocument())
+    expect(screen.getByText(/your bidding history/i)).toBeInTheDocument()
+  })
+})
+
+describe('BidderActivityPanel — isTerminal for remote chains', () => {
+  it('shows Counter and Withdraw buttons when chain status is "ongoing" (remote counter received)', async () => {
+    const offer = makeOffer({ my_negotiation_id: 99 })
+    // ongoing = remote-bank peer vocabulary for "owner countered, bidder's turn"
+    const negotiation = makeNegotiation({
+      id: 99,
+      status: 'ongoing',
+      last_action_by: { owner_type: 'client', owner_id: 2 },
+    })
+
+    jest
+      .mocked(otcOptionsApi.listMyNegotiations)
+      .mockResolvedValue({ negotiations: [negotiation], total: 1 })
+    jest.mocked(otcOptionsApi.listNegotiations).mockResolvedValue({ negotiations: [], total: 0 })
+
+    renderWithProviders(<BidderActivityPanel {...defaultProps} offer={offer} />)
+    expect(await screen.findByRole('button', { name: /counter/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /withdraw/i })).toBeInTheDocument()
+  })
+
+  it('hides Counter and Withdraw buttons when chain status is "accepted" (terminal)', async () => {
+    const offer = makeOffer({ my_negotiation_id: 99 })
+    const negotiation = makeNegotiation({ id: 99, status: 'accepted' })
+
+    jest
+      .mocked(otcOptionsApi.listMyNegotiations)
+      .mockResolvedValue({ negotiations: [negotiation], total: 1 })
+    jest.mocked(otcOptionsApi.listNegotiations).mockResolvedValue({ negotiations: [], total: 0 })
+
+    renderWithProviders(<BidderActivityPanel {...defaultProps} offer={offer} />)
+    await screen.findByText(/your bidding history/i)
+    expect(screen.queryByRole('button', { name: /counter/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /withdraw/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/views/otcOptions/components/BidderActivityPanel.tsx
+++ b/src/views/otcOptions/components/BidderActivityPanel.tsx
@@ -20,6 +20,8 @@ import {
   useOtcNegotiationRevisions,
 } from '@/views/otcOptions/hooks/useOtcOptionsLists'
 import { NegotiationRevisionsTable } from '@/views/otcOptions/components/NegotiationRevisionsTable'
+import { isNegotiationActive } from '@/views/otcOptions/lib/negotiationStatus'
+import { hasOwnNegotiationChain } from '@/views/otcOptions/lib/myNegotiation'
 
 interface Props {
   offer: OtcOptionRow
@@ -43,10 +45,18 @@ export function BidderActivityPanel({ offer, accounts, currentBidder, onBack, on
   const counter = useCounterNegotiation(offerId)
   const withdraw = useWithdrawNegotiation(offerId)
 
-  const myChain: OtcNegotiation | undefined = useMemo(
-    () => data?.negotiations?.find((n) => Number(n.parent_offer_id ?? n.offer_id ?? 0) === offerId),
-    [data, offerId]
-  )
+  const myChain: OtcNegotiation | undefined = useMemo(() => {
+    if (!data?.negotiations) return undefined
+    // Primary: use the offer's my_negotiation_id — the direct bidder-chain id
+    // returned by the discovery feed (spec §47.2). For remote offers the
+    // parent_offer_id on the mirror row is the seller-bank's id (not our local
+    // surrogate), so we can't rely on that fallback alone.
+    if (hasOwnNegotiationChain(offer.my_negotiation_id)) {
+      const negotiationId = Number(offer.my_negotiation_id)
+      return data.negotiations.find((n) => n.id === negotiationId)
+    }
+    return data.negotiations.find((n) => Number(n.parent_offer_id ?? n.offer_id ?? 0) === offerId)
+  }, [data, offer.my_negotiation_id, offerId])
 
   // Whose move is it? If the chain's last_action_by matches the bidder, the
   // owner is expected to respond; otherwise it's the bidder's turn.
@@ -154,7 +164,7 @@ function YourChainBody({
   onWithdraw: () => void
 }) {
   const [showCounterForm, setShowCounterForm] = useState(false)
-  const isTerminal = !(chain.status === 'open' || chain.status === 'countered')
+  const isTerminal = !isNegotiationActive(chain.status)
 
   // The "Your chain" panel now leads with the full revision history so the
   // bidder sees every back-and-forth with the owner — the snapshot of the

--- a/src/views/otcPortal/OtcPortalView.tsx
+++ b/src/views/otcPortal/OtcPortalView.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import {
   useOtcOffers,
+  useRemoteOptionOffers,
   useBuyOtcOffer,
   useBuyOtcOfferOnBehalf,
-  useCreatePeerOtcNegotiation,
+  usePlaceBidOnRemoteOffer,
 } from '@/hooks/useOtc'
 import { useClientAccounts, useAccountsByClient } from '@/hooks/useAccounts'
 import { useAllClients } from '@/hooks/useClients'
@@ -12,6 +13,7 @@ import { useAppSelector } from '@/hooks/useAppSelector'
 import { selectUserType, selectCurrentUser } from '@/store/selectors/authSelectors'
 import { notifySuccess } from '@/lib/errors'
 import type { OtcOffer, OtcLocalOffer, OtcRemoteOffer } from '@/types/otc'
+import type { OtcOptionRow, PlaceBidPayload } from '@/views/otcOptions/types'
 import { BuyOnBehalfOtcDialog } from '@/views/otcPortal/components/BuyOnBehalfOtcDialog'
 import { BuyOtcDialog } from '@/views/otcPortal/components/BuyOtcDialog'
 import { BuyRemoteOtcDialog } from '@/views/otcPortal/components/BuyRemoteOtcDialog'
@@ -19,13 +21,38 @@ import { OtcOffersTable } from '@/views/otcPortal/components/OtcOffersTable'
 import { OtcPeersStatusBanner } from '@/views/otcPortal/components/OtcPeersStatusBanner'
 import { LoadingState, ViewShell } from '@/views/shared'
 
+function remoteOptionToOffer(row: OtcOptionRow): OtcRemoteOffer {
+  return {
+    kind: 'remote',
+    id: Number(row.offer_id),
+    bank_code: row.bank_code,
+    owner_id:
+      typeof row.seller_id === 'string'
+        ? row.seller_id
+        : String((row.seller_id as { id: string | number }).id ?? ''),
+    security_type: 'stock',
+    ticker: row.ticker,
+    quantity: Number(row.amount),
+    price_per_unit: row.strike_price,
+    currency: row.strike_currency,
+  }
+}
+
 export function OtcPortalView() {
   const userType = useAppSelector(selectUserType)
   const currentUser = useAppSelector(selectCurrentUser)
   const isEmployee = userType === 'employee'
 
   const { data, isLoading } = useOtcOffers()
-  const offers = data?.offers ?? []
+  const { data: remoteOptionData } = useRemoteOptionOffers()
+
+  // Local stock offers from /otc/stocks + remote option offers from /otc/options?kind=remote.
+  // Remote stock entries from /otc/stocks carry no id and cannot be bid on; remote option rows
+  // from the options discovery feed carry a local surrogate offer_id required by /otc/options/:id/bid.
+  const offers: OtcOffer[] = [
+    ...(data?.offers ?? []).filter((o) => o.kind === 'local'),
+    ...(remoteOptionData?.offers ?? []).filter((o) => o.kind === 'remote').map(remoteOptionToOffer),
+  ]
 
   const [selectedOffer, setSelectedOffer] = useState<OtcOffer | null>(null)
   const [selectedClientId, setSelectedClientId] = useState<number | null>(null)
@@ -40,7 +67,7 @@ export function OtcPortalView() {
 
   const buyMutation = useBuyOtcOffer()
   const buyOnBehalfMutation = useBuyOtcOfferOnBehalf()
-  const peerNegotiationMutation = useCreatePeerOtcNegotiation()
+  const placeBidMutation = usePlaceBidOnRemoteOffer()
 
   const closeDialog = () => {
     setSelectedOffer(null)
@@ -59,15 +86,19 @@ export function OtcPortalView() {
             if (!open) closeDialog()
           }}
           offer={remoteOffer}
-          onSubmit={(payload) =>
-            peerNegotiationMutation.mutate(payload, {
-              onSuccess: () => {
-                notifySuccess('Negotiation submitted to peer bank.')
-                closeDialog()
-              },
-            })
+          accounts={clientAccounts}
+          onSubmit={(payload: PlaceBidPayload) =>
+            placeBidMutation.mutate(
+              { offerId: remoteOffer.id, ...payload },
+              {
+                onSuccess: () => {
+                  notifySuccess('Bid submitted to peer bank.')
+                  closeDialog()
+                },
+              }
+            )
           }
-          loading={peerNegotiationMutation.isPending}
+          loading={placeBidMutation.isPending}
         />
       )
     }

--- a/src/views/otcPortal/__tests__/BuyRemoteOtcDialog.test.tsx
+++ b/src/views/otcPortal/__tests__/BuyRemoteOtcDialog.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { BuyRemoteOtcDialog } from '@/views/otcPortal/components/BuyRemoteOtcDialog'
 import { createMockRemoteOtcOffer } from '@/__tests__/fixtures/otc-fixtures'
+import { createMockAccount } from '@/__tests__/fixtures/account-fixtures'
 
 jest.mock('@/components/ui/select', () => require('@/__tests__/mocks/select-mock'))
 
@@ -12,6 +13,7 @@ describe('BuyRemoteOtcDialog', () => {
     owner_id: '0',
     currency: 'USD',
   })
+  const accounts = [createMockAccount({ id: 7, account_name: 'Main', currency_code: 'USD' })]
 
   function setup() {
     const onSubmit = jest.fn()
@@ -21,6 +23,7 @@ describe('BuyRemoteOtcDialog', () => {
         open
         onOpenChange={onOpenChange}
         offer={offer}
+        accounts={accounts}
         onSubmit={onSubmit}
         loading={false}
       />
@@ -30,34 +33,29 @@ describe('BuyRemoteOtcDialog', () => {
 
   it('renders header with ticker and seller bank', () => {
     setup()
-    expect(screen.getByText(/negotiate msft with bank 333/i)).toBeInTheDocument()
+    expect(screen.getByText(/bid on msft/i)).toBeInTheDocument()
+    expect(screen.getByText(/bank 333/i)).toBeInTheDocument()
   })
 
   it('disables Submit until required fields are valid', () => {
     setup()
-    expect(screen.getByRole('button', { name: /submit negotiation/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /submit bid/i })).toBeDisabled()
   })
 
-  it('builds the negotiation payload from form inputs', () => {
+  it('builds the PlaceBidPayload from form inputs', () => {
     const { onSubmit } = setup()
-    fireEvent.change(screen.getByLabelText(/^amount$/i), { target: { value: '2' } })
-    fireEvent.change(screen.getByLabelText(/settlement date/i), {
-      target: { value: '2027-08-01' },
-    })
-    fireEvent.change(screen.getByLabelText(/price per unit/i), {
-      target: { value: '175' },
-    })
-    fireEvent.change(screen.getByLabelText(/^premium$/i), { target: { value: '40' } })
-    fireEvent.click(screen.getByRole('button', { name: /submit negotiation/i }))
+    fireEvent.change(screen.getByLabelText(/quantity/i), { target: { value: '2' } })
+    fireEvent.change(screen.getByLabelText(/strike price/i), { target: { value: '175.00' } })
+    fireEvent.change(screen.getByLabelText(/premium/i), { target: { value: '40.00' } })
+    fireEvent.change(screen.getByLabelText(/settlement date/i), { target: { value: '2027-08-01' } })
+    fireEvent.click(screen.getByRole('button', { name: /submit bid/i }))
 
     expect(onSubmit).toHaveBeenCalledWith({
-      seller_bank_code: '333',
-      seller_id: '0',
-      stock: { ticker: 'MSFT' },
-      amount: 2,
-      settlement_date: new Date('2027-08-01').toISOString(),
-      price_per_unit: { amount: '175', currency: 'USD' },
-      premium: { amount: '40', currency: 'USD' },
+      bidder_account_id: 7,
+      quantity: '2',
+      strike_price: '175.00',
+      premium: '40.00',
+      settlement_date: '2027-08-01',
     })
   })
 })

--- a/src/views/otcPortal/__tests__/OtcPortalView.test.tsx
+++ b/src/views/otcPortal/__tests__/OtcPortalView.test.tsx
@@ -46,13 +46,16 @@ describe('OtcPortalView', () => {
       .mocked(useOtcHook.useOtcOffers)
       .mockReturnValue(anyVal({ data: { offers, total_count: 1 }, isLoading: false }))
     jest
+      .mocked(useOtcHook.useRemoteOptionOffers)
+      .mockReturnValue(anyVal({ data: { offers: [], total_count: 0 }, isLoading: false }))
+    jest
       .mocked(useOtcHook.useBuyOtcOffer)
       .mockReturnValue(anyVal({ mutate: buyMutateFn, isPending: false }))
     jest
       .mocked(useOtcHook.useBuyOtcOfferOnBehalf)
       .mockReturnValue(anyVal({ mutate: buyOnBehalfMutateFn, isPending: false }))
     jest
-      .mocked(useOtcHook.useCreatePeerOtcNegotiation)
+      .mocked(useOtcHook.usePlaceBidOnRemoteOffer)
       .mockReturnValue(anyVal({ mutate: jest.fn(), isPending: false }))
     jest
       .mocked(useAccountsHook.useClientAccounts)

--- a/src/views/otcPortal/components/BuyRemoteOtcDialog.tsx
+++ b/src/views/otcPortal/components/BuyRemoteOtcDialog.tsx
@@ -17,43 +17,49 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import type { OtcRemoteOffer, PeerOtcNegotiationRequest } from '@/types/otc'
+import type { OtcRemoteOffer } from '@/types/otc'
+import type { Account } from '@/types/account'
+import type { PlaceBidPayload } from '@/views/otcOptions/types'
 
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
   offer: OtcRemoteOffer
-  onSubmit: (payload: PeerOtcNegotiationRequest) => void
+  accounts: Account[]
+  onSubmit: (payload: PlaceBidPayload) => void
   loading: boolean
 }
 
-const CURRENCIES = ['USD', 'EUR', 'RSD', 'GBP', 'CHF']
-
-export function BuyRemoteOtcDialog({ open, onOpenChange, offer, onSubmit, loading }: Props) {
-  const [amount, setAmount] = useState(1)
+export function BuyRemoteOtcDialog({
+  open,
+  onOpenChange,
+  offer,
+  accounts,
+  onSubmit,
+  loading,
+}: Props) {
+  const [accountId, setAccountId] = useState<number | undefined>(accounts[0]?.id)
+  const [quantity, setQuantity] = useState('1')
+  const [strikePrice, setStrikePrice] = useState('')
+  const [premium, setPremium] = useState('0')
   const [settlementDate, setSettlementDate] = useState('')
-  const [priceAmount, setPriceAmount] = useState('')
-  const [priceCurrency, setPriceCurrency] = useState(offer.currency || 'USD')
-  const [premiumAmount, setPremiumAmount] = useState('')
-  const [premiumCurrency, setPremiumCurrency] = useState(offer.currency || 'USD')
 
   const isValid =
-    amount > 0 &&
-    amount <= offer.quantity &&
-    settlementDate.length > 0 &&
-    Number(priceAmount) > 0 &&
-    Number(premiumAmount) >= 0
+    accountId !== undefined &&
+    Number(quantity) > 0 &&
+    Number(quantity) <= offer.quantity &&
+    Number(strikePrice) > 0 &&
+    Number(premium) >= 0 &&
+    settlementDate.length > 0
 
   const handleSubmit = () => {
     if (!isValid) return
     onSubmit({
-      seller_bank_code: offer.bank_code,
-      seller_id: offer.owner_id,
-      stock: { ticker: offer.ticker },
-      amount,
-      settlement_date: new Date(settlementDate).toISOString(),
-      price_per_unit: { amount: priceAmount, currency: priceCurrency },
-      premium: { amount: premiumAmount || '0', currency: premiumCurrency },
+      bidder_account_id: accountId!,
+      quantity,
+      strike_price: strikePrice,
+      premium,
+      settlement_date: settlementDate,
     })
   }
 
@@ -62,10 +68,10 @@ export function BuyRemoteOtcDialog({ open, onOpenChange, offer, onSubmit, loadin
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            Negotiate {offer.ticker} with bank {offer.bank_code}
+            Bid on {offer.ticker} — bank {offer.bank_code}
           </DialogTitle>
           <DialogDescription>
-            Cross-bank OTC option negotiation — initiates an SI-TX offer against the seller bank.
+            Cross-bank OTC option bid — dispatched to the seller's bank via SI-TX.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3 py-2">
@@ -73,14 +79,51 @@ export function BuyRemoteOtcDialog({ open, onOpenChange, offer, onSubmit, loadin
             Available: <strong>{offer.quantity}</strong>
           </p>
           <div>
-            <Label htmlFor="remote-amount">Amount</Label>
+            <Label htmlFor="remote-account">Account</Label>
+            <Select value={accountId?.toString()} onValueChange={(v) => setAccountId(Number(v))}>
+              <SelectTrigger id="remote-account">
+                <SelectValue placeholder="Select account" />
+              </SelectTrigger>
+              <SelectContent>
+                {accounts.map((a) => (
+                  <SelectItem key={a.id} value={a.id.toString()}>
+                    {a.account_name} ({a.currency_code})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="remote-quantity">Quantity</Label>
             <Input
-              id="remote-amount"
+              id="remote-quantity"
               type="number"
               min={1}
               max={offer.quantity}
-              value={amount}
-              onChange={(e) => setAmount(Number(e.target.value))}
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="remote-strike">Strike price</Label>
+            <Input
+              id="remote-strike"
+              type="number"
+              step="0.01"
+              min={0}
+              value={strikePrice}
+              onChange={(e) => setStrikePrice(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="remote-premium">Premium</Label>
+            <Input
+              id="remote-premium"
+              type="number"
+              step="0.01"
+              min={0}
+              value={premium}
+              onChange={(e) => setPremium(e.target.value)}
             />
           </div>
           <div>
@@ -92,69 +135,13 @@ export function BuyRemoteOtcDialog({ open, onOpenChange, offer, onSubmit, loadin
               onChange={(e) => setSettlementDate(e.target.value)}
             />
           </div>
-          <div className="grid grid-cols-[1fr_8rem] gap-2">
-            <div>
-              <Label htmlFor="remote-price-amount">Price per unit</Label>
-              <Input
-                id="remote-price-amount"
-                type="number"
-                step="0.01"
-                min={0}
-                value={priceAmount}
-                onChange={(e) => setPriceAmount(e.target.value)}
-              />
-            </div>
-            <div>
-              <Label htmlFor="remote-price-currency">Currency</Label>
-              <Select value={priceCurrency} onValueChange={(v) => v && setPriceCurrency(v)}>
-                <SelectTrigger id="remote-price-currency" aria-label="Price currency">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {CURRENCIES.map((c) => (
-                    <SelectItem key={c} value={c}>
-                      {c}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <div className="grid grid-cols-[1fr_8rem] gap-2">
-            <div>
-              <Label htmlFor="remote-premium-amount">Premium</Label>
-              <Input
-                id="remote-premium-amount"
-                type="number"
-                step="0.01"
-                min={0}
-                value={premiumAmount}
-                onChange={(e) => setPremiumAmount(e.target.value)}
-              />
-            </div>
-            <div>
-              <Label htmlFor="remote-premium-currency">Currency</Label>
-              <Select value={premiumCurrency} onValueChange={(v) => v && setPremiumCurrency(v)}>
-                <SelectTrigger id="remote-premium-currency" aria-label="Premium currency">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {CURRENCIES.map((c) => (
-                    <SelectItem key={c} value={c}>
-                      {c}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button onClick={handleSubmit} disabled={!isValid || loading}>
-            {loading ? 'Submitting…' : 'Submit negotiation'}
+            {loading ? 'Submitting…' : 'Submit bid'}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
…mote chain lookup

Three cross-bank OTC bugs fixed:

1. POST /me/peer-otc/negotiations (404) → replaced with POST /otc/options/:id/bid via otcOptionsApi.placeBid; BuyRemoteOtcDialog rewritten for PlaceBidPayload (bidder_account_id, quantity, strike_price, premium, settlement_date).

2. /otc/options/undefined/bid → OtcPortalView now fetches remote rows from GET /otc/options?kind=remote (which carries a local surrogate offer_id) instead of GET /otc/stocks (which has no id for remote entries).

3. Bidder cannot see negotiation chain after receiving counter notification:
   - BidderActivityPanel.myChain lookup now uses offer.my_negotiation_id as the primary match key; the previous parent_offer_id heuristic fails for remote chains where that field stores the seller bank's id, not the local surrogate.
   - isTerminal now delegates to isNegotiationActive(), which includes 'ongoing' (the SI-TX peer status for an active remote chain); Counter/Withdraw buttons were previously hidden for all remote counters.
   - OTC notification types added to NotificationType; NotificationDropdown navigates to /otc/options on any OTC_* notification click.