### PR TITLE
fix(otc): display remote stocks from /otc/stocks as view-only in the …

### DIFF
--- a/src/__tests__/fixtures/otc-fixtures.ts
+++ b/src/__tests__/fixtures/otc-fixtures.ts
@@ -20,7 +20,7 @@ export function createMockOtcOffer(overrides: Partial<OtcLocalOffer> = {}): OtcL
 export function createMockRemoteOtcOffer(overrides: Partial<OtcRemoteOffer> = {}): OtcRemoteOffer {
   return {
     kind: 'remote',
-    id: 10,
+    id: 10, // default: biddable (options-style). Pass id: undefined for a view-only remote stock.
     bank_code: '333',
     owner_id: '0',
     security_type: 'stock',

--- a/src/types/otc.ts
+++ b/src/types/otc.ts
@@ -20,8 +20,10 @@ export interface OtcLocalOffer {
 
 export interface OtcRemoteOffer {
   kind: 'remote'
-  /** Local surrogate id assigned by stock-service discovery cache — used to address /otc/options/:id/bid. */
-  id: number
+  /** Local surrogate id from the options discovery feed — only present for entries sourced from
+   *  GET /otc/options?kind=remote. Absent for raw remote stocks from GET /otc/stocks.
+   *  Required by POST /otc/options/:id/bid; omission means the offer is view-only. */
+  id?: number
   bank_code: string
   owner_id: string
   security_type: 'stock' | 'futures'

--- a/src/views/otcPortal/OtcPortalView.tsx
+++ b/src/views/otcPortal/OtcPortalView.tsx
@@ -46,11 +46,10 @@ export function OtcPortalView() {
   const { data, isLoading } = useOtcOffers()
   const { data: remoteOptionData } = useRemoteOptionOffers()
 
-  // Local stock offers from /otc/stocks + remote option offers from /otc/options?kind=remote.
-  // Remote stock entries from /otc/stocks carry no id and cannot be bid on; remote option rows
-  // from the options discovery feed carry a local surrogate offer_id required by /otc/options/:id/bid.
+  // All /otc/stocks entries (local + remote stocks, the latter without id) plus remote option rows
+  // from /otc/options?kind=remote which carry a local surrogate offer_id for POST /otc/options/:id/bid.
   const offers: OtcOffer[] = [
-    ...(data?.offers ?? []).filter((o) => o.kind === 'local'),
+    ...(data?.offers ?? []),
     ...(remoteOptionData?.offers ?? []).filter((o) => o.kind === 'remote').map(remoteOptionToOffer),
   ]
 
@@ -79,6 +78,8 @@ export function OtcPortalView() {
 
     if (selectedOffer.kind === 'remote') {
       const remoteOffer: OtcRemoteOffer = selectedOffer
+      const optionOfferId = remoteOffer.id
+      if (!optionOfferId) return null // remote stock without option id — view-only, not biddable
       return (
         <BuyRemoteOtcDialog
           open
@@ -89,7 +90,7 @@ export function OtcPortalView() {
           accounts={clientAccounts}
           onSubmit={(payload: PlaceBidPayload) =>
             placeBidMutation.mutate(
-              { offerId: remoteOffer.id, ...payload },
+              { offerId: optionOfferId, ...payload },
               {
                 onSuccess: () => {
                   notifySuccess('Bid submitted to peer bank.')

--- a/src/views/otcPortal/__tests__/OtcOffersTable.test.tsx
+++ b/src/views/otcPortal/__tests__/OtcOffersTable.test.tsx
@@ -57,6 +57,13 @@ describe('OtcOffersTable', () => {
     expect(onBuy).toHaveBeenCalledWith(remote)
   })
 
+  it('shows "View only" for remote stock offers that have no option id (not biddable)', () => {
+    const remoteStock = createMockRemoteOtcOffer({ ticker: 'IBM', id: undefined })
+    render(<OtcOffersTable offers={[remoteStock]} onBuy={onBuy} />)
+    expect(screen.getByText(/view only/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /negotiate/i })).not.toBeInTheDocument()
+  })
+
   it('renders price with currency for remote offers with non-zero price', () => {
     const remote = createMockRemoteOtcOffer({ price_per_unit: '420.50', currency: 'EUR' })
     render(<OtcOffersTable offers={[remote]} onBuy={onBuy} />)

--- a/src/views/otcPortal/__tests__/OtcPortalView.test.tsx
+++ b/src/views/otcPortal/__tests__/OtcPortalView.test.tsx
@@ -4,7 +4,7 @@ import { OtcPortalView } from '@/views/otcPortal/OtcPortalView'
 import * as useOtcHook from '@/hooks/useOtc'
 import * as useAccountsHook from '@/hooks/useAccounts'
 import * as useClientsHook from '@/hooks/useClients'
-import { createMockOtcOffer } from '@/__tests__/fixtures/otc-fixtures'
+import { createMockOtcOffer, createMockRemoteOtcOffer } from '@/__tests__/fixtures/otc-fixtures'
 import { createMockAccount } from '@/__tests__/fixtures/account-fixtures'
 import { createMockClient } from '@/__tests__/fixtures/client-fixtures'
 import { createMockAuthState, createMockAuthUser } from '@/__tests__/fixtures/auth-fixtures'
@@ -80,6 +80,16 @@ describe('OtcPortalView', () => {
   it('renders offers in the table', () => {
     renderWithProviders(<OtcPortalView />, { preloadedState: clientAuth() })
     expect(screen.getByText('AAPL')).toBeInTheDocument()
+  })
+
+  it('renders remote stock entries from /otc/stocks in the table (view-only, no negotiate button)', () => {
+    const remoteStock = createMockRemoteOtcOffer({ ticker: 'TSLA', id: undefined })
+    jest
+      .mocked(useOtcHook.useOtcOffers)
+      .mockReturnValue({ data: { offers: [remoteStock], total_count: 1 }, isLoading: false } as any)
+    renderWithProviders(<OtcPortalView />, { preloadedState: clientAuth() })
+    expect(screen.getByText('TSLA')).toBeInTheDocument()
+    expect(screen.getByText(/view only/i)).toBeInTheDocument()
   })
 
   it('shows the loading state while fetching', () => {

--- a/src/views/otcPortal/components/OtcOffersTable.tsx
+++ b/src/views/otcPortal/components/OtcOffersTable.tsx
@@ -25,7 +25,10 @@ interface Props {
 
 function offerKey(offer: OtcOffer): string {
   if (offer.kind === 'local') return `local-${offer.id}`
-  return `remote-${offer.bank_code}-${offer.owner_id}-${offer.ticker}`
+  // Append the option surrogate id when present so a stock and an option on the
+  // same ticker from the same bank get distinct keys.
+  const suffix = offer.id != null ? `-${offer.id}` : ''
+  return `remote-${offer.bank_code}-${offer.owner_id}-${offer.ticker}${suffix}`
 }
 
 function formatPrice(offer: OtcOffer): string {
@@ -92,6 +95,8 @@ export function OtcOffersTable({ offers, onBuy, currentUserId, isCurrentUserEmpl
             <TableCell className="text-right">
               {isOwnedByViewer(offer) ? (
                 <span className="text-sm text-muted-foreground italic">Your offer</span>
+              ) : offer.kind === 'remote' && offer.id == null ? (
+                <span className="text-sm text-muted-foreground italic">View only</span>
               ) : (
                 <Button size="sm" variant="outline" onClick={() => onBuy(offer)}>
                   {offer.kind === 'local' ? 'Buy' : 'Negotiate'}


### PR DESCRIPTION
…trading table

Remote stock entries from GET /otc/stocks were filtered out after the previous fix because they carry no surrogate id (required by POST /otc/options/:id/bid). They are now included for market visibility with a "View only" badge instead of a Negotiate button.

- OtcRemoteOffer.id is now optional: present only for entries sourced from GET /otc/options?kind=remote; absent for raw remote stocks from GET /otc/stocks
- OtcPortalView no longer filters remote entries from GET /otc/stocks
- OtcOffersTable renders "View only" for remote offers without an option id
- renderDialog guards against opening the bid dialog for view-only entries
- offerKey disambiguates stock vs option rows for the same ticker/bank